### PR TITLE
Use Yoga plugin instead of wrapping the schema

### DIFF
--- a/docs/src/pages/examples/graphql-yoga.md
+++ b/docs/src/pages/examples/graphql-yoga.md
@@ -9,10 +9,6 @@ An example using our GraphQL API with [GraphQL Yoga](https://the-guild.dev/graph
 
 ---
 
-{% callout %}
-**Note**: Using GraphQL Yoga with Next.js for this example requires using top-level await, which is [not currently supported by SWC](https://github.com/vercel/next.js/issues/31054). The example repository provides the `.babelrc` and `next.config.js` changes to enable top-level await with Babel and Webpack 5.
-{% /callout %}
-
 ## Quick Start
 
 1. Create your application using `create-next-app`
@@ -37,13 +33,12 @@ const remoteExecutor = buildHTTPExecutor({
 
 ## GraphQL API Route Example
 
-To add the Canopy API schema to an existing Next.js GraphQL API Route with GraphQL Yoga, you will need to use `@graphql-tools/stitch` and add the `Authorization` header. Here is an example:
+To add the Canopy API schema to an existing Next.js GraphQL API Route with GraphQL Yoga, you will need to use `@graphql-tools/executor-yoga` and add the `Authorization` header. Here is an example:
 
 ```typescript
 import { buildHTTPExecutor } from '@graphql-tools/executor-http'
-import { schemaFromExecutor } from '@graphql-tools/wrap'
 import { createYoga } from 'graphql-yoga'
-import { stitchSchemas } from '@graphql-tools/stitch'
+import { useExecutor } from "@graphql-tools/executor-yoga"
 
 const CANOPY_GRAPHQL_ENDPOINT = 'https://endpoint.canopyapi.co/'
 
@@ -61,18 +56,11 @@ export const config = {
   },
 }
 
-const canopySubschema = {
-  schema: await schemaFromExecutor(remoteExecutor),
-  executor: remoteExecutor,
-}
-
-const schema = stitchSchemas({
-  subschemas: [canopySubschema],
-})
-
 export default createYoga({
-  schema,
+  plugins: [
+    useExecutor(remoteExecutor),
+  ],
   // Needed to be defined explicitly because our endpoint lives at a different path other than `/graphql`
-  graphqlEndpoint: '/api/graphql',
-})
+  graphqlEndpoint: "/api/graphql",
+});
 ```

--- a/examples/next-with-graphql-yoga/package.json
+++ b/examples/next-with-graphql-yoga/package.json
@@ -7,8 +7,7 @@
   },
   "dependencies": {
     "@graphql-tools/executor-http": "^0.1.6",
-    "@graphql-tools/stitch": "^8.7.40",
-    "@graphql-tools/wrap": "^9.3.5",
+    "@graphql-tools/executor-yoga": "^1.0.1",
     "graphql": "^16.5.0",
     "graphql-yoga": "^3.5.1",
     "next": "^13.1.6",

--- a/examples/next-with-graphql-yoga/pages/api/graphql.ts
+++ b/examples/next-with-graphql-yoga/pages/api/graphql.ts
@@ -1,7 +1,6 @@
-import { buildHTTPExecutor } from "@graphql-tools/executor-http";
-import { schemaFromExecutor } from "@graphql-tools/wrap";
 import { createYoga } from "graphql-yoga";
-import { stitchSchemas } from "@graphql-tools/stitch";
+import { buildHTTPExecutor } from "@graphql-tools/executor-http";
+import { useExecutor } from "@graphql-tools/executor-yoga";
 
 const CANOPY_GRAPHQL_ENDPOINT = "https://endpoint.canopyapi.co/";
 
@@ -19,17 +18,10 @@ export const config = {
   },
 };
 
-const canopySubschema = {
-  schema: await schemaFromExecutor(remoteExecutor),
-  executor: remoteExecutor,
-};
-
-const schema = stitchSchemas({
-  subschemas: [canopySubschema],
-});
-
 export default createYoga({
-  schema,
+  plugins: [
+    useExecutor(remoteExecutor),
+  ],
   // Needed to be defined explicitly because our endpoint lives at a different path other than `/graphql`
   graphqlEndpoint: "/api/graphql",
 });


### PR DESCRIPTION
Hi there! It is Arda from @the-guild-org !
I'm one of the maintainers of GraphQL Yoga and GraphQL Tools!
I did some small improvements with this PR.

You don't need to wrap the schema, you can just use the introspected non-executable schema and attach the remote executor to Yoga/Envelop with `@graphql-tools/executor-yoga`.

Let me know PR looks good to you! Thanks!